### PR TITLE
Add 'template_notices' hook to 'library.php' template

### DIFF
--- a/templates/buddypress/groups/single/library.php
+++ b/templates/buddypress/groups/single/library.php
@@ -11,6 +11,8 @@
 			</div>
 		</div>
 
+		<?php do_action( 'template_notices' ); ?>
+
 		<div class="group-library-refreshable">
 			<div class="library-loading">
 				Loading...


### PR DESCRIPTION
This PR adds the BuddyPress `'template_notices'` hook to the `library.php` template part.

As outlined internally, there's an issue with using this approach to adding a template notice due to how the Vue app wipes out any HTML markup after the group library is loaded via AJAX.

Feel free to use a different approach to adding the template notice!