### PR TITLE
Set 'group-documents-category' taxonomy to non-public

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -64,6 +64,8 @@ class App {
 			999
 		);
 
+		$this->group_doc_taxonomy_mods();
+
 		if ( defined( 'WP_CLI' ) ) {
 			$this->set_up_cli_commands();
 		}
@@ -156,6 +158,19 @@ class App {
 	protected function set_up_cli_commands() {
 		\WP_CLI::add_command( 'cacgl database', '\CAC\GroupLibrary\CLI\Command\DatabaseCommand' );
 		\WP_CLI::add_command( 'cacgl sync', '\CAC\GroupLibrary\CLI\Command\SyncCommand' );
+	}
+
+	/**
+	 * Ensures 'group-documents-category' taxonomy is not public.
+	 */
+	protected function group_doc_taxonomy_mods() {
+		add_filter(
+			'register_group-documents-category_taxonomy_args',
+			function( $args ) {
+				$args['public'] = false;
+				return $args;
+			}
+		);
 	}
 
 	public function __get( $key ) {


### PR DESCRIPTION
`cac-group-library` doesn't use the categories feature from BuddyPress Group Documents, so set the taxonomy to non-public to prevent the taxonomy from showing up in `wp-sitemap.xml`.

As I was writing this PR, I was thinking that instead of this PR, we could also unregister the taxonomy as well.

----

Semi-related, since `cac-group-library` doesn't use the categories feature from BuddyPress Group Documents, we could also think about deleting the ['bp_group_documents_use_categories' and 'bp_group_documents_upload_permission' options](https://github.com/cuny-academic-commons/cac/blob/b4d33ad7fc11019c0cea52b1b95ed7e38587567d/wp-content/plugins/buddypress-group-documents/index.php#L66-L70). Then, we wouldn't need to do the following nav mods as well: https://github.com/cuny-academic-commons/cac-group-library/blob/ca819efcca12d397e5048ddeb1928a30d7e7c814/src/Nav.php#L36-L39